### PR TITLE
Fixed rules.yml to be valid YAML

### DIFF
--- a/iban-tools.gemspec
+++ b/iban-tools.gemspec
@@ -2,7 +2,7 @@ Gem::Specification.new do |s|
   s.platform     = Gem::Platform::RUBY
   s.summary      = "IBAN validator"
   s.name         = 'iban-tools'
-  s.version      = '0.0.7.1'
+  s.version      = '0.0.7.2'
   s.authors      = ["Iulian Dogariu", "Joni Lahtinen"]
   s.email        = ["code@iuliandogariu.com"]
   s.requirements << 'none'

--- a/lib/iban-tools/rules.yml
+++ b/lib/iban-tools/rules.yml
@@ -3,37 +3,37 @@
 "AD":
   # Andorra
   length: 24
-  bban_pattern: "\d{8}[A-Z0-9]{12}"
+  bban_pattern: "\\d{8}[A-Z0-9]{12}"
 
 "AE":
   # United Arab Emirates
   length: 23
-  bban_pattern: "\d{19}"
+  bban_pattern: "\\d{19}"
 
 "AL":
   # Albania
   length: 28
-  bban_pattern: "\d{8}[A-Z0-9]{16}"
+  bban_pattern: "\\d{8}[A-Z0-9]{16}"
 
 "AT":
   # Austria
   length: 20
-  bban_pattern: "\d{16}"
+  bban_pattern: "\\d{16}"
 
 "BA":
   # Bosnia
   length: 20
-  bban_pattern: "\d{16}"
+  bban_pattern: "\\d{16}"
 
 "BE":
   # Belgium
   length: 16
-  bban_pattern: "\d{12}"
+  bban_pattern: "\\d{12}"
 
 "BG":
   # Bulgaria
   length: 22
-  bban_pattern: "[A-Z]{4}\d{6}[A-Z0-9]{8}"
+  bban_pattern: "[A-Z]{4}\\d{6}[A-Z0-9]{8}"
 
 "BH":
   # Bahrain
@@ -43,67 +43,67 @@
 "CH":
   # Switzerland
   length: 21
-  bban_pattern: "\d{5}[A-Z0-9]{12}"
+  bban_pattern: "\\d{5}[A-Z0-9]{12}"
 
 "CY":
   # Cyprus
   length: 28
-  bban_pattern: "\d{8}[A-Z0-9]{16}"
+  bban_pattern: "\\d{8}[A-Z0-9]{16}"
 
 "CZ":
   # Czech Republic
   length: 24
-  bban_pattern: "\d{20}"
+  bban_pattern: "\\d{20}"
 
 "DE":
   # Germany
   length: 22
-  bban_pattern: "\d{18}"
+  bban_pattern: "\\d{18}"
 
 "DK":
   # Denmark
   length: 18
-  bban_pattern: "\d{14}"
+  bban_pattern: "\\d{14}"
 
 "DO":
   # Dominican Republic
   length: 28
-  bban_pattern: "[A-Z]{4}\d{20}"
+  bban_pattern: "[A-Z]{4}\\d{20}"
 
 "EE":
   # Estonia
   length: 20
-  bban_pattern: "\d{16}"
+  bban_pattern: "\\d{16}"
 
 "ES":
   # Spain
   length: 24
-  bban_pattern: "\d{20}"
+  bban_pattern: "\\d{20}"
 
 "FI":
   # Finland
   length: 18
-  bban_pattern: "\d{14}"
+  bban_pattern: "\\d{14}"
 
 "FO":
   # Faroe Islands
   length: 18
-  bban_pattern: "\d{14}"
+  bban_pattern: "\\d{14}"
 
 "FR":
   # France
   length: 27
-  bban_pattern: "\d{10}[A-Z0-9]{11}\d{2}"
+  bban_pattern: "\\d{10}[A-Z0-9]{11}\\d{2}"
 
 "GB":
   # United Kingdom
   length: 22
-  bban_pattern: "[A-Z]{4}\d{14}"
+  bban_pattern: "[A-Z]{4}\\d{14}"
 
 "GE":
   # Georgia
   length: 22
-  bban_pattern: "[A-Z]{2}\d{16}"
+  bban_pattern: "[A-Z]{2}\\d{16}"
 
 "GI":
   # Gibraltar
@@ -113,72 +113,72 @@
 "GL":
   # Greenland
   length: 18
-  bban_pattern: "\d{14}"
+  bban_pattern: "\\d{14}"
 
 "GR":
   # Greece
   length: 27
-  bban_pattern: "\d{7}[A-Z0-9]{16}"
+  bban_pattern: "\\d{7}[A-Z0-9]{16}"
 
 "HR":
   # Croatia
   length: 21
-  bban_pattern: "\d{17}"
+  bban_pattern: "\\d{17}"
 
 "HU":
   # Hungary
   length: 28
-  bban_pattern: "\d{24}"
+  bban_pattern: "\\d{24}"
 
 "IE":
   # Ireland
   length: 22
-  bban_pattern: "[A-Z]{4}\d{14}"
+  bban_pattern: "[A-Z]{4}\\d{14}"
 
 "IL":
   # Israel
   length: 23
-  bban_pattern: "\d{19}"
+  bban_pattern: "\\d{19}"
 
 "IS":
   # Iceland
   length: 26
-  bban_pattern: "\d{22}"
+  bban_pattern: "\\d{22}"
 
 "IT":
   # Italy
   length: 27
-  bban_pattern: "[A-Z]\d{10}[A-Z0-9]{12}"
+  bban_pattern: "[A-Z]\\d{10}[A-Z0-9]{12}"
 
 "KW":
   # Kuwait
   length: 30
-  bban_pattern: "[A-Z]{4}\d{22}"
+  bban_pattern: "[A-Z]{4}\\d{22}"
 
 "KZ":
   # Kazakhstan
   length: 20
-  bban_pattern: "\d{3}[A-Z]{3}\d{10}"
+  bban_pattern: "\\d{3}[A-Z]{3}\\d{10}"
 
 "LB":
   # Lebanon
   length: 28
-  bban_pattern: "\d{4}[A-Z0-9]{20}"
+  bban_pattern: "\\d{4}[A-Z0-9]{20}"
 
 "LI":
   # Liechtenstein
   length: 21
-  bban_pattern: "\d{5}[A-Z0-9]{12}"
+  bban_pattern: "\\d{5}[A-Z0-9]{12}"
 
 "LT":
   # Lithuania
   length: 20
-  bban_pattern: "\d{16}"
+  bban_pattern: "\\d{16}"
 
 "LU":
   # Luxembourg
   length: 20
-  bban_pattern: "\d{3}[A-Z0-9]{13}"
+  bban_pattern: "\\d{3}[A-Z0-9]{13}"
 
 "LV":
   # Latvia
@@ -188,52 +188,52 @@
 "MC":
   # Monaco
   length: 27
-  bban_pattern: "\d{10}[A-Z0-9]{11}\d{2}"
+  bban_pattern: "\\d{10}[A-Z0-9]{11}\\d{2}"
 
 "ME":
   # Montenegro
   length: 22
-  bban_pattern: "\d{18}"
+  bban_pattern: "\\d{18}"
 
 "MK":
   # Macedonia
   length: 19
-  bban_pattern: "\d{3}[A-Z0-9]{10}\d{2}"
+  bban_pattern: "\\d{3}[A-Z0-9]{10}\\d{2}"
 
 "MR":
   # Mauritania
   length: 27
-  bban_pattern: "\d{23}"
+  bban_pattern: "\\d{23}"
 
 "MT":
   # Malta
   length: 31
-  bban_pattern: "[A-Z]{4}\d{5}[A-Z0-9]{18}"
+  bban_pattern: "[A-Z]{4}\\d{5}[A-Z0-9]{18}"
 
 "MU":
   # Mauritius
   length: 30
-  bban_pattern: "[A-Z]{4}\d{19}[A-Z]{3}"
+  bban_pattern: "[A-Z]{4}\\d{19}[A-Z]{3}"
 
 "NL":
   # Netherlands
   length: 18
-  bban_pattern: "[A-Z]{4}\d{10}"
+  bban_pattern: "[A-Z]{4}\\d{10}"
 
 "NO":
   # Norway
   length: 15
-  bban_pattern: "\d{11}"
+  bban_pattern: "\\d{11}"
 
 "PL":
   # Poland
   length: 28
-  bban_pattern: "\d{8}[A-Z0-9]{16}"
+  bban_pattern: "\\d{8}[A-Z0-9]{16}"
 
 "PT":
   # Portugal
   length: 25
-  bban_pattern: "\d{21}"
+  bban_pattern: "\\d{21}"
 
 "RO":
   # Romania
@@ -243,40 +243,39 @@
 "RS":
   # Serbia
   length: 22
-  bban_pattern: "\d{18}"
+  bban_pattern: "\\d{18}"
 
 "SA":
   # Saudi Arabia
   length: 24
-  bban_pattern: "\d{2}[A-Z0-9]{18}"
+  bban_pattern: "\\d{2}[A-Z0-9]{18}"
 
 "SE":
   # Sweden
   length: 24
-  bban_pattern: "\d{20}"
+  bban_pattern: "\\d{20}"
 
 "SI":
   # Slovenia
   length: 19
-  bban_pattern: "\d{15}"
+  bban_pattern: "\\d{15}"
 
 "SK":
   # Slovakia
   length: 24
-  bban_pattern: "\d{20}"
+  bban_pattern: "\\d{20}"
 
 "SM":
   # San Marino
   length: 27
-  bban_pattern: "[A-Z]\d{10}[A-Z0-9]{12}"
+  bban_pattern: "[A-Z]\\d{10}[A-Z0-9]{12}"
 
 "TN":
   # Tunisia
   length: 24
-  bban_pattern: "\d{20}"
+  bban_pattern: "\\d{20}"
 
 "TR":
   # Turkey
   length: 26
-  bban_pattern: "\d{5}[A-Z0-9]{17}"
-
+  bban_pattern: "\\d{5}[A-Z0-9]{17}"


### PR DESCRIPTION
Ruby 1.9.3 YAML validator does not recognize character `\d` and throws an error. This fixes the problem.